### PR TITLE
Publish on tags via trusted npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
-name: Publish to npm
+name: Publish Package
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*'
 
 jobs:
   publish:
@@ -21,8 +21,11 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
Update the publish workflow to follow npm trusted publishing guidance:
- Trigger on version tags (v*) instead of direct pushes to master.
- Ensure npm is up to date, use npm ci, run tests/build, then publish with provenance.

This aligns with trusted publisher setup and avoids master push triggers.