### PR TITLE
Use pnpm in CI workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,25 +15,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
-
-      - name: Update npm
-        run: npm install -g npm@latest
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: npm test
+        run: pnpm test
 
       - name: Build
-        run: npm run build
+        run: pnpm build
 
       - name: Publish (trusted publishing)
         env:
           NPM_CONFIG_PROVENANCE: true
-        run: npm publish --access public --provenance
+        run: pnpm publish --access public --provenance

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,16 +15,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: npm test
+        run: pnpm test
 
       - name: Build
-        run: npm run build
+        run: pnpm build


### PR DESCRIPTION
Switch CI to pnpm:
- publish: tag-triggered, pnpm install/test/build/publish with provenance
- tests: pnpm install --frozen-lockfile, pnpm test/build

This replaces the npm CI steps with pnpm to align with the lockfile and avoid npm ci errors.