### PR TITLE
fix: Use npm publish for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Publish (trusted publishing)
         env:
           NPM_CONFIG_PROVENANCE: true
-        run: pnpm publish --access public --provenance --no-git-checks
+        run: npm publish --access public --provenance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scix-mcp",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "MCP server for NASA Astrophysics Data System API",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Switch from pnpm publish to npm publish in the GitHub Actions workflow. pnpm doesn't properly support npm's OIDC trusted publishing workflow, causing 404 errors even with correct trusted publisher configuration.

- Bump version to 1.0.11